### PR TITLE
Fix Sysexmessages

### DIFF
--- a/.idea/artifacts/processingLibrariesLocal.xml
+++ b/.idea/artifacts/processingLibrariesLocal.xml
@@ -4,7 +4,6 @@
     <root id="root">
       <element id="directory" name="pLaunchControl">
         <element id="directory" name="library">
-          <element id="file-copy" path="$PROJECT_DIR$/export.txt" />
           <element id="archive" name="pLaunchControl.jar">
             <element id="directory" name="META-INF">
               <element id="file-copy" path="$PROJECT_DIR$/META-INF/MANIFEST.MF" />
@@ -12,6 +11,27 @@
             <element id="module-output" name="pLaunchController" />
           </element>
           <element id="library" level="project" name="uk.co.xfactory.librarians.coremidi4j" />
+        </element>
+        <element id="directory" name="examples">
+          <element id="dir-copy" path="$PROJECT_DIR$/examples" />
+        </element>
+        <element id="file-copy" path="$PROJECT_DIR$/library.properties" />
+      </element>
+      <element id="archive" name="pLaunchControl.zip">
+        <element id="directory" name="src">
+          <element id="module-source" name="pLaunchController" />
+        </element>
+        <element id="directory" name="library">
+          <element id="archive" name="pLaunchControl.jar">
+            <element id="module-output" name="pLaunchController" />
+            <element id="directory" name="META-INF">
+              <element id="file-copy" path="$PROJECT_DIR$/META-INF/MANIFEST.MF" />
+            </element>
+          </element>
+          <element id="library" level="project" name="uk.co.xfactory.librarians.coremidi4j" />
+        </element>
+        <element id="directory" name="reference">
+          <element id="dir-copy" path="$PROJECT_DIR$/reference" />
         </element>
         <element id="directory" name="examples">
           <element id="dir-copy" path="$PROJECT_DIR$/examples" />

--- a/.idea/artifacts/processingLibrariesLocal.xml
+++ b/.idea/artifacts/processingLibrariesLocal.xml
@@ -11,6 +11,7 @@
             </element>
             <element id="module-output" name="pLaunchController" />
           </element>
+          <element id="library" level="project" name="uk.co.xfactory.librarians.coremidi4j" />
         </element>
         <element id="directory" name="examples">
           <element id="dir-copy" path="$PROJECT_DIR$/examples" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,12 +6,15 @@
     </artifacts-to-build>
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="79e7d7a1-5c5b-44e1-a6be-83c5765af82f" name="Default" comment="Udpated references to pLaunchControl and small change to artefact creation">
+    <list default="true" id="79e7d7a1-5c5b-44e1-a6be-83c5765af82f" name="Default" comment="Introduces the dependency to coremidi4j, which also fixes the Sysex messages (related to #8). This commit fixes LaunchControl implementation only (a few remaining changes to LaunchControlXL are needed).">
       <change beforePath="$PROJECT_DIR$/.idea/artifacts/processingLibrariesLocal.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/artifacts/processingLibrariesLocal.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/examples/LaunchControlDemo/LaunchControlDemo.pde" beforeDir="false" afterPath="$PROJECT_DIR$/examples/LaunchControlDemo/LaunchControlDemo.pde" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/library.properties" beforeDir="false" afterPath="$PROJECT_DIR$/library.properties" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pLaunchController.iml" beforeDir="false" afterPath="$PROJECT_DIR$/pLaunchController.iml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pLaunchController.xml" beforeDir="false" afterPath="$PROJECT_DIR$/pLaunchController.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/pLaunchControl/LaunchControl.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/pLaunchControl/LaunchControl.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/pLaunchControl/LaunchControlDeviceReceiver.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/pLaunchControl/LaunchControlDeviceReceiver.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/pLaunchControl/LaunchControlXL.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/pLaunchControl/LaunchControlXL.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -210,6 +213,8 @@
       <recent name="C:\CreativeCoding\Java\pLaunchController\.github" />
     </key>
     <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/" />
+      <recent name="$PROJECT_DIR$/resources" />
       <recent name="$PROJECT_DIR$/examples/LaunchControllerDemo" />
       <recent name="C:\CreativeCoding\Java\pLaunchController\examples" />
     </key>
@@ -416,7 +421,14 @@
       <option name="project" value="LOCAL" />
       <updated>1649771327186</updated>
     </task>
-    <option name="localTasksCounter" value="17" />
+    <task id="LOCAL-00017" summary="Introduces the dependency to coremidi4j, which also fixes the Sysex messages. This commit fixes LaunchControl implementation only (a few remaining changes to LaunchControlXL are needed).">
+      <created>1649776928780</created>
+      <option name="number" value="00017" />
+      <option name="presentableId" value="LOCAL-00017" />
+      <option name="project" value="LOCAL" />
+      <updated>1649776928780</updated>
+    </task>
+    <option name="localTasksCounter" value="18" />
     <servers />
   </component>
   <component name="ToolWindowManager">
@@ -457,7 +469,7 @@
                   <entry key="branch">
                     <value>
                       <list>
-                        <option value="launchControlXL" />
+                        <option value="fix-sysexmessage" />
                       </list>
                     </value>
                   </entry>
@@ -486,7 +498,8 @@
     <MESSAGE value="Initial renaming from pLaunchController to pLaunchControl. It does not include updates to documentation.&#10;Relates to #6" />
     <MESSAGE value="Implementation of LaunchControlXL.java and the required refactoring related to it. This change introduces issue #7" />
     <MESSAGE value="Udpated references to pLaunchControl and small change to artefact creation" />
-    <option name="LAST_COMMIT_MESSAGE" value="Udpated references to pLaunchControl and small change to artefact creation" />
+    <MESSAGE value="Introduces the dependency to coremidi4j, which also fixes the Sysex messages. This commit fixes LaunchControl implementation only (a few remaining changes to LaunchControlXL are needed)." />
+    <option name="LAST_COMMIT_MESSAGE" value="Introduces the dependency to coremidi4j, which also fixes the Sysex messages. This commit fixes LaunchControl implementation only (a few remaining changes to LaunchControlXL are needed)." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -497,7 +510,7 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
           <url>file://$PROJECT_DIR$/src/pLaunchControl/LaunchControl.java</url>
-          <line>61</line>
+          <line>63</line>
           <option name="timeStamp" value="2" />
         </line-breakpoint>
       </breakpoints>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,85 +7,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="79e7d7a1-5c5b-44e1-a6be-83c5765af82f" name="Default" comment="Udpated references to pLaunchControl and small change to artefact creation">
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController.zip" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/examples/SuperShape2D/SuperShape2D.pde" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/examples/Vertices/Vertices.pde" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/library/export.txt" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/library/pLaunchController.jar" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/allclasses-frame.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/allclasses-noframe.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/constant-values.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/deprecated-list.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/help-doc.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-1.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-10.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-11.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-12.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-13.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-14.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-2.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-3.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-4.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-5.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-6.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-7.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-8.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index-files/index-9.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/index.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/overview-tree.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/KNOBS.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/Knob.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/LaunchController.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/LaunchControllerReceiver.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/LedConstants.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/Messages.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/PADS.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/package-frame.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/package-summary.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/pLaunchController/package-tree.html" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/package-list" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/script.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/artifacts/pLaunchController/reference/stylesheet.css" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/production/pLaunchController/pLaunchController/KNOBS.class" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/production/pLaunchController/pLaunchController/Knob.class" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/production/pLaunchController/pLaunchController/LaunchController.class" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/production/pLaunchController/pLaunchController/LaunchControllerReceiver.class" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/production/pLaunchController/pLaunchController/LedConstants.class" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/production/pLaunchController/pLaunchController/PADMODE.class" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/out/production/pLaunchController/pLaunchController/PADS.class" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/allclasses-frame.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/allclasses-frame.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/allclasses-noframe.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/allclasses-noframe.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/constant-values.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/constant-values.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/deprecated-list.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/deprecated-list.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/help-doc.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/help-doc.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-1.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-1.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-10.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-10.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-11.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-11.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-12.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-12.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-13.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-13.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-14.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-14.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-2.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-2.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-3.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-3.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-4.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-4.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-5.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-5.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-6.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-6.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-7.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-7.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-8.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-8.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index-files/index-9.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index-files/index-9.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/index.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/overview-tree.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/overview-tree.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/KNOBS.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/KNOBS.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/Knob.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/Knob.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/LaunchController.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/LaunchController.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/LaunchControllerReceiver.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/LaunchControllerReceiver.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/LedConstants.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/LedConstants.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/Messages.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/Messages.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/PADMODE.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/PADMODE.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/PADS.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/PADS.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/package-frame.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/package-frame.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/package-summary.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/package-summary.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/pLaunchController/package-tree.html" beforeDir="false" afterPath="$PROJECT_DIR$/reference/pLaunchController/package-tree.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/reference/package-list" beforeDir="false" afterPath="$PROJECT_DIR$/reference/package-list" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/artifacts/processingLibrariesLocal.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/artifacts/processingLibrariesLocal.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pLaunchController.iml" beforeDir="false" afterPath="$PROJECT_DIR$/pLaunchController.iml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/pLaunchControl/LaunchControl.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/pLaunchControl/LaunchControl.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/pLaunchControl/LaunchControlDeviceReceiver.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/pLaunchControl/LaunchControlDeviceReceiver.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -128,7 +54,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="master" />
+        <entry key="$PROJECT_DIR$" value="launchControlXL" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -261,10 +187,14 @@
     <option name="showLibraryContents" value="true" />
   </component>
   <component name="PropertiesComponent">
+    <property name="Downloaded.Files.Path.Enabled" value="false" />
     <property name="GenerateAntBuildDialog.backupFiles" value="true" />
     <property name="GenerateAntBuildDialog.forceTargetJdk" value="true" />
     <property name="GenerateAntBuildDialog.generateSingleFile" value="true" />
     <property name="GenerateAntBuildDialog.outputFileNameProperty" value="pLaunchController" />
+    <property name="Repository.Attach.Annotations" value="false" />
+    <property name="Repository.Attach.JavaDocs" value="false" />
+    <property name="Repository.Attach.Sources" value="false" />
     <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
     <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
     <property name="SHARE_PROJECT_CONFIGURATION_FILES" value="true" />

--- a/examples/LaunchControlDemo/LaunchControlDemo.pde
+++ b/examples/LaunchControlDemo/LaunchControlDemo.pde
@@ -9,83 +9,87 @@ import pLaunchControl.*;
 
 LaunchControl controller;
 
-        void setup() {
-        size(1000, 500);
+void setup() {
+  size(1000, 500);
 
-        try {
-        controller = new LaunchControl(this, true);
-        }
-        catch(Exception e) {
-        println("Unfortunately we could not detect that Launch Control is connected to this computer :(");
-        }
-        textAlign(CENTER);
-        }
+  try {
+    controller = new LaunchControl(this, true);
+    // If you have renamed your Launch Control in the system
+    // preferences, use this version of the constructor:
+    // controller = new LaunchControl(this, true, "THE NAME YOU GAVE TO THE CONTROLLER");
+  }
+  catch(Exception e) {
+    println("Unfortunately we could not detect that Launch Control is connected to this computer :(");
+    println(e);
+    noLoop();
+  }
+  textAlign(CENTER);
+}
 
 
-        void draw() {
-        background(0);
-        translate(20, 20);
-        stroke(255);
-        strokeWeight(3);
-        float s = width/16;
-        translate(s/2, s);
-
-        drawKnobs(s);
-        drawPads(s);
-
-        }
+void draw() {
+  background(0);
+  translate(20, 20);
+  stroke(255);
+  strokeWeight(3);
+  float s = width/16;
+  translate(s/2, s);
+  if (controller !=null) {
+    drawKnobs(s);
+    drawPads(s);
+  }
+}
 
 /**
  * Draws the knobs of the controller as simple arcs.
  */
-        void drawKnobs(float s) {
+void drawKnobs(float s) {
 
-        //drawing positions
-        float start = HALF_PI * 1.3;
-        float end = TWO_PI + HALF_PI * .7;
+  //drawing positions
+  float start = HALF_PI * 1.3;
+  float end = TWO_PI + HALF_PI * .7;
 
-        pushMatrix();
-        for (int i = 0; i < 16; i++) {
-        //draw knob background, simple arc
-        fill(255);
-        arc(2*s*(i%8), 0, s, s, start, end);
+  pushMatrix();
+  for (int i = 0; i < 16; i++) {
+    //draw knob background, simple arc
+    fill(255);
+    arc(2*s*(i%8), 0, s, s, start, end);
 
-        //draw knob position
-        fill(80);
-        Knob knob = controller.getKnob(i);
-        float normal = knob.valueNormal();
-        float realValue = knob.value();
+    //draw knob position
+    fill(80);
+    Knob knob = controller.getKnob(i);
+    float normal = knob.valueNormal();
+    float realValue = knob.value();
 
-        arc(2*s*(i%8), 0, s, s, start, start + normal*(end-start));
-        fill(255);
-        text(round(realValue), 2*s*(i%8), s );
+    arc(2*s*(i%8), 0, s, s, start, start + normal*(end-start));
+    fill(255);
+    text(round(realValue), 2*s*(i%8), s );
 
-        if (i == 7)
-        translate(0, height * .3);
-        }
-        popMatrix();
-        }
+    if (i == 7)
+      translate(0, height * .3);
+  }
+  popMatrix();
+}
 
 /**
  * Draws the pads of the controller as simple arcs.
  */
-        void drawPads(float s) {
-        translate(0,height * .6);
-        rectMode(CENTER);
+void drawPads(float s) {
+  translate(0, height * .6);
+  rectMode(CENTER);
 
-        for (int i = 0; i < 8; i++) {
-        //draw pad background, simple arc
-        fill(255);
-        rect(2*s*i,0,s,s);
+  for (int i = 0; i < 8; i++) {
+    //draw pad background, simple arc
+    fill(255);
+    rect(2*s*i, 0, s, s);
 
-        //draw pad state position
-        fill(80);
-        boolean padState = controller.getPad(i).value();
-        if(padState)
-        rect(2*s*i,0,s,s);
+    //draw pad state position
+    fill(80);
+    boolean padState = controller.getPad(i).value();
+    if (padState)
+      rect(2*s*i, 0, s, s);
 
-        fill(255);
-        text(round(i), 2*s*(i%8), s );
-
-        }
-        }
+    fill(255);
+    text(round(i), 2*s*(i%8), s );
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 # UTF-8 supported.
 
 # The name of your library as you want it formatted.
-name = Novation Launch Controller client
+name = Novation Launch Control client
 
 # List of authors. Links can be provided using the syntax [author name](url).
-authors = [Half Scheidl](https://github.com/haschdl)
+authors = [Half Scheidl](https://github.com/haschdl), [Jonathan Newman](https://github.com/poetoflight)
 
 # A web page for your library, NOT a direct link to where to download it.
 url = https://github.com/haschdl/pLaunchController
@@ -24,15 +24,14 @@ categories = I/O
 # repeating the name of your library here. Also, avoid saying anything redundant
 # like mentioning that it's a library. This should start with a capitalized
 # letter, and end with a period.
-sentence = Control your sketches using the knobs and pads from Novation &reg; Launch Control&reg;.
+sentence = Control your sketches using the knobs, pads and slider from MIDI controllers such as Novation &reg; Launch Control&reg;.
 
 # Additional information suitable for the Processing website. The value of
 # 'sentence' always will be prepended, so you should start by writing the
 # second sentence here. If your library only works on certain operating systems,
 # mention it here.
-paragraph = Once connected to your computer, use the MIDI controller to control your sketch by\
-  adjusting the values of variables. This is library is not created by or supported by Novation, \
-  the manufacturer of the device. It uses standard MIDI protocols, thus does not require any additional drivers.
+paragraph = Once connected to your computer, use the MIDI controller to control your sketch by \
+  adjusting the values of variables. This is library is not created by or supported by Novation.
 
 # Links in the 'sentence' and 'paragraph' attributes can be inserted using the
 # same syntax as for authors.
@@ -42,11 +41,11 @@ paragraph = Once connected to your computer, use the MIDI controller to control 
 # compare different versions of the same library, and check if an update is
 # available. You should think of it as a counter, counting the total number of
 # releases you've had.
-version = 4  # This must be parsable as an int
+version = 5  # This must be parsable as an int
 
 # The version as the user will see it. If blank, the version attribute will be
 # used here. This should be a single word, with no spaces.
-prettyVersion = 1.2  # This is treated as a String
+prettyVersion = 2.0.0-alpha  # This is treated as a String
 
 # The min and max revision of Processing compatible with your library.
 # Note that these fields use the revision and not the version of Processing,

--- a/pLaunchController.iml
+++ b/pLaunchController.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/pLaunchController.iml
+++ b/pLaunchController.iml
@@ -8,5 +8,6 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="processing4" level="project" />
+    <orderEntry type="library" name="uk.co.xfactory.librarians.coremidi4j" level="project" />
   </component>
 </module>

--- a/pLaunchController.xml
+++ b/pLaunchController.xml
@@ -217,7 +217,7 @@
       <zipfileset dir="${basedir}/src" prefix="pLaunchController/src"/>
       <zipfileset file="${basedir}/export.txt" prefix="pLaunchController/library"/>
       <zipfileset file="${temp.jar.path.pLaunchController.jar2}" prefix="pLaunchController/library"/>
-      <zipfileset dir="${basedir}/examples" prefix="pLaunchController/examples"/>
+      <zipfileset dir="/resources/examples" prefix="pLaunchController/examples"/>
       <zipfileset file="${basedir}/library.properties" prefix="pLaunchController"/>
     </zip>
     <mkdir dir="${artifact.output.processinglib}/pLaunchController"/>
@@ -226,7 +226,7 @@
     <copy file="${temp.jar.path.pLaunchController.jar}" tofile="${artifact.output.processinglib}/pLaunchController/library/pLaunchController.jar"/>
     <mkdir dir="${artifact.output.processinglib}/pLaunchController/examples"/>
     <copy todir="${artifact.output.processinglib}/pLaunchController/examples">
-      <fileset dir="${basedir}/examples"/>
+      <fileset dir="/resources/examples"/>
     </copy>
     <mkdir dir="${artifact.output.processinglib}/pLaunchController/src"/>
     <copy todir="${artifact.output.processinglib}/pLaunchController/src">

--- a/src/pLaunchControl/LaunchControl.java
+++ b/src/pLaunchControl/LaunchControl.java
@@ -6,6 +6,10 @@ import javax.sound.midi.MidiMessage;
 import javax.sound.midi.MidiSystem;
 import javax.sound.midi.MidiUnavailableException;
 import java.lang.reflect.Method;
+import uk.co.xfactorylibrarians.coremidi4j.CoreMidiDeviceProvider;
+import uk.co.xfactorylibrarians.coremidi4j.CoreMidiNotification;
+import uk.co.xfactorylibrarians.coremidi4j.CoreMidiException;
+
 
 import static processing.core.PApplet.println;
 
@@ -130,14 +134,15 @@ public class LaunchControl implements MidiDevice {
         for (int i = 0, l = PAD_COUNT; i < l; i++) {
             padValues[i] = new Pad(i,parent);
         }
-        infos = MidiSystem.getMidiDeviceInfo();
+        infos = CoreMidiDeviceProvider.getMidiDeviceInfo();
         for (javax.sound.midi.MidiDevice.Info info : infos) {
-            if (info.getName().equals("Launch Control")) {
-                javax.sound.midi.MidiDevice device = MidiSystem.getMidiDevice(info);
-                if (info.getClass().getName().equals("com.sun.media.sound.MidiInDeviceProvider$MidiInDeviceInfo")) {
+            javax.sound.midi.MidiDevice device = MidiSystem.getMidiDevice(info);
+            System.out.println(String.format("Device: %s \t Receivers: %d \t Transmitters: %d", info, device.getMaxReceivers(), device.getMaxTransmitters()));
+            if (info.getName().endsWith("Launch Control")) {
+                if (device.getMaxReceivers() == 0) {
                     deviceIn = device;
                     println("Connected to Launch Control MIDI Input.");
-                } else {
+                } else if(device.getMaxTransmitters()==0) {
                     println("Connected to Launch Control MIDI Output.");
                     deviceOut = device;
                 }

--- a/src/pLaunchControl/LaunchControl.java
+++ b/src/pLaunchControl/LaunchControl.java
@@ -6,6 +6,7 @@ import javax.sound.midi.MidiMessage;
 import javax.sound.midi.MidiSystem;
 import javax.sound.midi.MidiUnavailableException;
 import java.lang.reflect.Method;
+
 import uk.co.xfactorylibrarians.coremidi4j.CoreMidiDeviceProvider;
 import uk.co.xfactorylibrarians.coremidi4j.CoreMidiNotification;
 import uk.co.xfactorylibrarians.coremidi4j.CoreMidiException;
@@ -41,6 +42,7 @@ import static processing.core.PApplet.println;
  *
  */
 public class LaunchControl implements MidiDevice {
+    public static final String DEVICE_NAME_SUFFIX = "Launch Control";
     Method controllerChangedEventMethod, knobChangedEventMethod, padChangedEventMethod;
     private static final String controlChangedEventName = "LaunchControlChanged";
     private static final String knobChangedEventName = "LaunchControlKnobChanged";
@@ -80,7 +82,7 @@ public class LaunchControl implements MidiDevice {
     public Knob getKnob(int knobIndex) {
         //TODO validate knobIndex
         KNOBS knobAtPosition = KNOBS.values()[knobIndex];
-        return  knobValues[knobAtPosition.code()];
+        return knobValues[knobAtPosition.code()];
     }
 
 
@@ -122,35 +124,46 @@ public class LaunchControl implements MidiDevice {
         throw new UnsupportedOperationException("Method not available. This device does not have sliders.");
     }
 
-    public LaunchControl(PApplet parent) throws MidiUnavailableException {
-        this(parent, false);
-    }
+
     public LaunchControl(PApplet parent, boolean debug) throws MidiUnavailableException {
+        this(parent, debug, null);
+    }
+
+    public LaunchControl(PApplet parent) throws MidiUnavailableException {
+        this(parent, false, null);
+    }
+
+
+    public LaunchControl(PApplet parent, boolean debug, String deviceName) throws MidiUnavailableException {
         this.parent = parent;
-        this.debug=debug;
+        this.debug = debug;
         for (int i = 0, l = KNOB_COUNT; i < l; i++) {
             knobValues[i] = new Knob(i, parent);
         }
         for (int i = 0, l = PAD_COUNT; i < l; i++) {
-            padValues[i] = new Pad(i,parent);
+            padValues[i] = new Pad(i, parent);
         }
         infos = CoreMidiDeviceProvider.getMidiDeviceInfo();
         for (javax.sound.midi.MidiDevice.Info info : infos) {
             javax.sound.midi.MidiDevice device = MidiSystem.getMidiDevice(info);
-            System.out.println(String.format("Device: %s \t Receivers: %d \t Transmitters: %d", info, device.getMaxReceivers(), device.getMaxTransmitters()));
-            if (info.getName().endsWith("Launch Control")) {
+            if (this.debug)
+                System.out.println(String.format("Device: %s \t Receivers: %d \t Transmitters: %d", info, device.getMaxReceivers(), device.getMaxTransmitters()));
+            if ((deviceName != null && info.getName().endsWith(deviceName)) || info.getName().endsWith(DEVICE_NAME_SUFFIX)) {
                 if (device.getMaxReceivers() == 0) {
                     deviceIn = device;
-                    println("Connected to Launch Control MIDI Input.");
-                } else if(device.getMaxTransmitters()==0) {
-                    println("Connected to Launch Control MIDI Output.");
+                    println("Connected to MIDI Input.");
+                } else if (device.getMaxTransmitters() == 0) {
+                    println("Connected to MIDI Output.");
                     deviceOut = device;
                 }
             }
         }
 
         if (deviceIn == null) {
-            println("Launch Control not connected!");
+            if (deviceName == null)
+                System.out.printf("A device with name ending with %s was not detected.\n", DEVICE_NAME_SUFFIX);
+            else
+                System.out.printf("A device with name you provided was not detected.\nCheck the device name: %s \n", deviceName);
             return;
         }
 
@@ -221,7 +234,7 @@ public class LaunchControl implements MidiDevice {
     public Pad getPad(int padIndex) {
         //TODO validate padIndex
         PADS padAtPosition = PADS.values()[padIndex];
-        return  padValues[padAtPosition.code()];
+        return padValues[padAtPosition.code()];
     }
 
 
@@ -244,7 +257,7 @@ public class LaunchControl implements MidiDevice {
         if (padValues[pad.code()].value() != value) {
             padValues[pad.code()].value(value);
             receiver.sendLedOnOff(value, pad);
-            if(!disableEvents) {
+            if (!disableEvents) {
                 midiLaunchControlChanged();
                 padChanged(pad);
             }

--- a/src/pLaunchControl/LaunchControlDeviceReceiver.java
+++ b/src/pLaunchControl/LaunchControlDeviceReceiver.java
@@ -2,6 +2,8 @@ package pLaunchControl;
 
 import javax.naming.OperationNotSupportedException;
 import javax.sound.midi.MidiMessage;
+import uk.co.xfactorylibrarians.coremidi4j.CoreMidiReceiver;
+
 import javax.sound.midi.Receiver;
 import javax.sound.midi.SysexMessage;
 


### PR DESCRIPTION
This is a working version with support to Launch Control XL and restored functionality related to Sysexmessages.

Fix #10 related to hard-coded devices. If a user has multiple devices connected to the same host computer, they can update the name of the device in the OS settings. The name can be totally arbitrary. 
A new constructor is available, where Processing users can provide the device name. For example:
```Java
void setup() {
  size(980, 1000);
  try {
    controller = new LaunchControlXL(this, "Launch Control XL 123");
  }
  catch(Exception e) {
    println("Unfortunately we could not detect that Launch Control is connected to this computer :(");
  }
  setupKnobs();
}
```

Implementation of Launch Control XL support is a contribution by @poetoflight
